### PR TITLE
Support station mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ make
 make flash # this will flash using esptool.py over serial connection
 ```
 
+### Station Mode Configuration
 
+To use the ESP8266 in Station mode, in the Blackmagic configuration section:
+- Configure Station mode
+- Specify the SSID and password you wish to connect to.  *NOTE: The SSID is case sensitive*
+- (optional) Specify a hostname to make it easier to connect to the probe.
+
+### Development/Debug Configuration
+
+When working on blackmagic-espidf it is frequently desirable to continue to use the ESP8266 UART for debugging.  To achieve this you can disable `Monitor target UART` in the Blackmagic configuration section.
+
+In this mode you will be unable to use the ESP UART to monitor the target and connecting the ESP UART to the target may result in undefined behavior since the debug messages will be sent to the target.
 
 ## OTA Flashing
 

--- a/html/debug.html
+++ b/html/debug.html
@@ -22,7 +22,7 @@
         var fitAddon = new FitAddon.FitAddon();
         term.loadAddon(fitAddon);
         
-        var socket = new WebSocket("ws://192.168.4.1/debugws");
+        var socket = new WebSocket("ws://" + location.host + "/debugws");
         socket.onopen = function(e) {
           term.write("\x1B[1;3;31m[Websocket] Connection established\x1B[0m\r\n");
         };

--- a/html/index.html
+++ b/html/index.html
@@ -151,7 +151,7 @@
         var fitAddon = new FitAddon.FitAddon();
         term.loadAddon(fitAddon);
         
-        var socket = new WebSocket("ws://192.168.4.1/terminal");
+        var socket = new WebSocket("ws://" + location.host + "/terminal");
         socket.onopen = function(e) {
           term.write("\x1B[1;3;31m[Websocket] Connection established\x1B[0m\r\n");
         };

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -21,14 +21,14 @@ config ESP_WIFI_SSID
     string "WiFi SSID"
     default "auto"
     help
-	SSID (network name) for ap and sta modes.
-	auto - generates name automatically when in ap mode using mac address for ex. blackmagic_27FCF5E
+	   SSID (network name) for ap and sta modes.
+	   auto - generates name automatically when in ap mode using mac address for ex. blackmagic_27FCF5E
 
 config ESP_WIFI_PASSWORD
     string "WiFi Password"
     default "helloworld"
     help
-	WiFi password (WPA or WPA2) for the example to use.
+	   WiFi password (WPA or WPA2) for the example to use.
 		
 config MAX_STA_CONN
     int "Max STA conn"
@@ -65,5 +65,19 @@ config SRST_GPIO
     default 12
     help
 	Reset GPIO Number
+
+config TARGET_UART
+    bool "Monitor target UART"
+    default y
+    help
+        Uses the ESP8266 UART to pass through the target UART pins.
+
+        Disable to debug blackmagic-espidf.
+
+config BLACKMAGIC_HOSTNAME
+    string "Hostname"
+    default "blackmagic"
+    help
+        Hostname for the blackmagic probe.
 		
 endmenu

--- a/main/platform.c
+++ b/main/platform.c
@@ -354,7 +354,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event)
                  event->event_info.connected.ssid);
 #ifdef CONFIG_BLACKMAGIC_HOSTNAME
         tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, CONFIG_BLACKMAGIC_HOSTNAME);
-        
+
         ESP_LOGI("WIFI", "setting hostname:%s",
                   CONFIG_BLACKMAGIC_HOSTNAME);
 #endif
@@ -483,6 +483,7 @@ int putc_remote(int c) {
 void app_main(void) {
 #if CONFIG_TARGET_UART
 #warning Target UART configured.  ESP8266 debugging info will not be available via UART.
+  ESP_LOGI(__func__, "deactivating debug uart");
   esp_log_set_putchar(putc_noop);
 #endif
 


### PR DESCRIPTION
- Fix configuration options required for station mode (Issue #3)
- Fix setup for station mode (Issue #4)
- Add configuration option for hostname support in station mode
- Change webservice references to use connected host rather than hardcoded IP address
- Update documentation to describe configuration options